### PR TITLE
Fix lint warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Running Storybook
+
+To start Storybook locally, run:
+
+```bash
+pnpm storybook
+```
+
+This will launch Storybook at [http://localhost:6006](http://localhost:6006) by default.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/src/components/contexts/Toast.tsx
+++ b/src/components/contexts/Toast.tsx
@@ -30,15 +30,18 @@ interface ToastProviderProps {
 export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
-  const addToast = useCallback((message: string, type: ToastType = "info") => {
-    const id = Date.now();
-    setToasts((prevToasts) => [...prevToasts, { id, message, type }]);
-    setTimeout(() => removeToast(id), 3000); // this will auto remove the toast after 3 sec
-  }, []);
-
   const removeToast = useCallback((id: number) => {
     setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== id));
   }, []);
+
+  const addToast = useCallback(
+    (message: string, type: ToastType = "info") => {
+      const id = Date.now();
+      setToasts((prevToasts) => [...prevToasts, { id, message, type }]);
+      setTimeout(() => removeToast(id), 3000); // this will auto remove the toast after 3 sec
+    },
+    [removeToast]
+  );
 
   return (
     <ToastContext.Provider value={{ toasts, addToast, removeToast }}>

--- a/src/components/molecules/FaqAccordions/FaqAccordions.stories.tsx
+++ b/src/components/molecules/FaqAccordions/FaqAccordions.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Meta, StoryFn } from "@storybook/react";
+import { Meta, StoryFn } from "@storybook/nextjs";
 import FaqAccordions from "./FaqAccordions";
 
 export default {

--- a/src/components/molecules/Footer/Footer.stories.tsx
+++ b/src/components/molecules/Footer/Footer.stories.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Meta, StoryFn } from "@storybook/react";
+import { Meta, StoryFn } from "@storybook/nextjs";
 import Footer from "./Footer";
 
 export default {


### PR DESCRIPTION
This fixes most lint warnings. There is still one left about using `img` instead of Next.js' `Image` component. That's just temporary code and it doesn't seem to be worth fixing now.

Also taking the opportunity to add simple instructions to run Storybook.